### PR TITLE
Cursor position update

### DIFF
--- a/demo-app/src/routes/tasks.js
+++ b/demo-app/src/routes/tasks.js
@@ -17,11 +17,14 @@ router.get('/', (req, res) => {
 });
 
 // GET /tasks/:id — Get a single task
-// BUG: Uses == instead of === for comparison, and does not parse the param.
-// This causes req.params.id (string) == task.id (number) to work inconsistently.
-// It returns the wrong task or undefined in edge cases.
 router.get('/:id', (req, res) => {
-  const task = tasks.find(t => t.id == req.params.id);
+  const taskId = Number(req.params.id);
+
+  if (!Number.isInteger(taskId)) {
+    return res.status(400).json({ error: 'Invalid task id' });
+  }
+
+  const task = tasks.find(t => t.id === taskId);
 
   if (!task) {
     return res.status(404).json({ error: 'Task not found' });

--- a/demo-app/tests/tasks.test.js
+++ b/demo-app/tests/tasks.test.js
@@ -26,6 +26,12 @@ describe('GET /tasks/:id', () => {
     expect(res.status).toBe(404);
   });
 
+  it('should return 400 for non-numeric id', async () => {
+    const res = await request(app).get('/tasks/not-a-number');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid task id');
+  });
+
   // This test exposes the == vs === bug:
   // When id is passed as a string with leading zeros or special numeric strings,
   // the loose comparison can cause unexpected behavior.


### PR DESCRIPTION
Fix bug in `GET /tasks/:id` endpoint to handle non-numeric IDs with a 400 response and use strict comparison.

This resolves issue #1 by preventing a 500 error when a non-numeric ID is provided, instead returning a more appropriate 400 status. It also improves code robustness by using strict equality for ID comparison.

---
<p><a href="https://cursor.com/agents/bc-bef2f81e-56e4-498f-a32e-1b0b8f64024e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bef2f81e-56e4-498f-a32e-1b0b8f64024e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

